### PR TITLE
RATIS-1346. Add .asf.yaml to ratis-thirdparty

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Third-party dependencies for Apache Ratis"
+  homepage: http://ratis.apache.org/
+  labels:
+    - ratis
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ratis.apache.org
+  issues:       issues@ratis.apache.org
+  pullrequests: issues@ratis.apache.org
+  jira_options: link label worklog


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `.asf.yaml` to `ratis-thirdparty` repo with similar settings as in the main `ratis` repo.  The only differences are in the description and labels.

https://issues.apache.org/jira/browse/RATIS-1346

## How was this patch tested?

Notification and merge settings were already tested on the main repo.