### PR TITLE
RATIS-1348. Intermittent failure in GrpcSslTest

### DIFF
--- a/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
+++ b/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
@@ -73,7 +73,7 @@ public class GrpcSslTest {
       String user = "testuser";
       String response = client.greet(user);
       LOG.info("Greet result: {}", response);
-      Assert.assertTrue(response.equals("Hello " + user));
+      Assert.assertEquals("Hello " + user, response);
     } finally {
       client.shutdown();
     }

--- a/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
+++ b/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
@@ -40,20 +40,21 @@ public class GrpcSslTest {
 
   @Test
   public void testSslClientServer() throws InterruptedException, IOException {
+    GrpcSslServerConfig sslServerConf =
+        new GrpcSslServerConfig(
+            getResource("ssl/server.pem"),
+            getResource("ssl/server.crt"),
+            getResource("ssl/client.crt"),
+            true,
+            false);
+    GrpcSslServer server = new GrpcSslServer(port, sslServerConf);
+    server.start();
+
     Thread serverThread = new Thread(() -> {
-      GrpcSslServerConfig sslServerConf =
-          new GrpcSslServerConfig(
-              getResource("ssl/server.pem"),
-              getResource("ssl/server.crt"),
-              getResource("ssl/client.crt"),
-              true,
-              false);
-      GrpcSslServer server = new GrpcSslServer(port, sslServerConf);
       try {
-        server.start();
         server.blockUntilShutdown();
-      } catch (InterruptedException | IOException e) {
-        e.printStackTrace();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     });
     serverThread.start();

--- a/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcTest.java
+++ b/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcTest.java
@@ -34,14 +34,15 @@ public class GrpcTest {
 
   private final static Logger LOG = LoggerFactory.getLogger(GrpcTest.class);
   @Test
-  public void testClientServer() throws InterruptedException {
+  public void testClientServer() throws IOException, InterruptedException {
+    GrpcServer server = new GrpcServer(50001);
+    server.start();
+
     Thread serverThread = new Thread(() -> {
-      GrpcServer server = new GrpcServer(50001);
       try {
-        server.start();
         server.blockUntilShutdown();
-      } catch (InterruptedException | IOException e) {
-        e.printStackTrace();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     });
     serverThread.start();

--- a/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcTest.java
+++ b/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcTest.java
@@ -53,7 +53,7 @@ public class GrpcTest {
       String user = "testuser";
       String response = client.greet(user);
       LOG.info("Greet result: {}", response);
-      Assert.assertTrue(response.equals("Hello " + user));
+      Assert.assertEquals("Hello " + user, response);
     } finally {
       client.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure due to threading problem in `GrpcSslTest`, and similar one (although not yet encountered) in `GrpcTest`.

Start the server in the main thread, only the blocking call needs to be pushed to a separate thread.

https://issues.apache.org/jira/browse/RATIS-1348

## How was this patch tested?

Reproduced the problem by adding `sleep(2000)` before `server.start()` in the original code.  With the fix such delay does not affect client's connection.

CI runs:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/667445986
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/667453955
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/667456741
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/667461303