### PR TITLE
RATIS-1496. Upgrade gRPC to 1.43.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
 
     <!--Version of protobuf to be shaded -->
-    <shaded.protobuf.version>3.12.0</shaded.protobuf.version>
+    <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.42.1</shaded.grpc.version>
+    <shaded.grpc.version>1.43.2</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
     <shaded.netty.version>4.1.63.Final</shaded.netty.version>
     <!--Version of tcnative to be shaded -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump gPRC to 1.43.2, the latest version which supports Netty 4.1.63.

Bump Protobuf to 3.19.2.

https://issues.apache.org/jira/browse/RATIS-1496

## How was this patch tested?

Built Ratis with thirdparty upgraded to 0.8.0-SNAPSHOT, ran tests.

Built Ozone with them and ran some acceptance tests (HA, secure HA, compatibility).

CI:
https://github.com/adoroszlai/ratis-thirdparty/runs/4869330477