### PR TITLE
RATIS-1514. Bundle specific netty artifacts instead of netty-all

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -50,7 +50,23 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+      <classifier>osx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-aarch_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -161,13 +177,22 @@
                   </excludes>
                 </filter>
                 <filter>
-                  <artifact>io.netty:netty-all</artifact>
+                  <artifact>io.netty:netty-resolver-dns-native-macos</artifact>
                   <excludes>
                     <exclude>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib</exclude>
-                    <exclude>META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>io.netty:netty-transport-native-epoll</artifact>
+                  <excludes>
                     <exclude>META-INF/native/libnetty_transport_native_epoll_x86_64.so</exclude>
                     <exclude>META-INF/native/libnetty_transport_native_epoll_aarch_64.so</exclude>
-                    <exclude>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>io.netty:netty-transport-native-kqueue</artifact>
+                  <excludes>
+                    <exclude>META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -181,17 +206,9 @@
                   <exclude>com.google.code.findbugs:jsr305</exclude>
                   <exclude>com.google.errorprone:error_prone_annotations</exclude>
                   <exclude>com.google.j2objc:j2objc-annotations</exclude>
-                  <!-- Specifying netty-all gets all of these -->
-                  <exclude>io.netty:netty-buffer</exclude>
-                  <exclude>io.netty:netty-codec-http2</exclude>
-                  <exclude>io.netty:netty-codec-http</exclude>
+                  <!-- Transitive stuff we don't need from netty -->
                   <exclude>io.netty:netty-codec-socks</exclude>
-                  <exclude>io.netty:netty-codec</exclude>
-                  <exclude>io.netty:netty-common</exclude>
                   <exclude>io.netty:netty-handler-proxy</exclude>
-                  <exclude>io.netty:netty-handler</exclude>
-                  <exclude>io.netty:netty-resolver</exclude>
-                  <exclude>io.netty:netty-transport</exclude>
                   <!-- Transitive stuff we don't need coming from google deps -->
                   <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
                 </excludes>
@@ -219,7 +236,12 @@
             </goals>
             <configuration>
               <includeGroupIds>io.netty</includeGroupIds>
-              <includeArtifactIds>netty-tcnative-boringssl-static, netty-all</includeArtifactIds>
+              <includeArtifactIds>
+                netty-resolver-dns-native-macos,
+                netty-tcnative-boringssl-static,
+                netty-transport-native-epoll,
+                netty-transport-native-kqueue
+              </includeArtifactIds>
               <includes>**/META-INF/native/*</includes>
               <outputDirectory>${project.build.directory}/classes/</outputDirectory>
               <overWriteReleases>true</overWriteReleases>

--- a/misc/src/main/appended-resources/META-INF/NOTICE
+++ b/misc/src/main/appended-resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ Copyright 2014 The gRPC Authors
 
 ---
 
-This product bundles netty-all which includes the following text:
+This product bundles Netty which includes the following text:
 
 Copyright 2014 The Netty Project
 

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,10 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
+        <artifactId>netty-bom</artifactId>
         <version>${shaded.netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis Thirdparty bundles `netty-all` with lots of exclusions.  The contents of the `netty-all` JAR may change between releases.  This PR proposes to bundle specific Netty artifacts instead.  This way we could avoid silently adding more Netty code during upgrades.

https://issues.apache.org/jira/browse/RATIS-1514

## How was this patch tested?

Built Ratis Thirdparty.
Built Ratis with it, ran unit tests.
Built Ozone with custom Ratis, ran some basic acceptance tests.

Diff of `ratis-thirdparty-misc` jar contents between `master` and this PR:

```diff
--- /dev/fd/12	2022-01-30 20:11:05.974531227 +0100
+++ /dev/fd/13	2022-01-30 20:11:05.975024344 +0100
@@ -39,16 +39,59 @@
     testing: META-INF/maven/com.google.protobuf/protobuf-java/pom.properties   OK
     testing: META-INF/maven/com.google.protobuf/protobuf-java/pom.xml   OK
     testing: META-INF/maven/io.netty/   OK
-    testing: META-INF/maven/io.netty/netty-all/   OK
-    testing: META-INF/maven/io.netty/netty-all/pom.properties   OK
-    testing: META-INF/maven/io.netty/netty-all/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-buffer/   OK
+    testing: META-INF/maven/io.netty/netty-buffer/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-buffer/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-codec-dns/   OK
+    testing: META-INF/maven/io.netty/netty-codec-dns/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-codec-dns/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-codec-http/   OK
+    testing: META-INF/maven/io.netty/netty-codec-http/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-codec-http/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-codec-http2/   OK
+    testing: META-INF/maven/io.netty/netty-codec-http2/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-codec-http2/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-codec/   OK
+    testing: META-INF/maven/io.netty/netty-codec/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-codec/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-common/   OK
+    testing: META-INF/maven/io.netty/netty-common/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-common/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-handler/   OK
+    testing: META-INF/maven/io.netty/netty-handler/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-handler/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns-native-macos/   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns-native-macos/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns-native-macos/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns/   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-resolver-dns/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-resolver/   OK
+    testing: META-INF/maven/io.netty/netty-resolver/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-resolver/pom.xml   OK
     testing: META-INF/maven/io.netty/netty-tcnative-boringssl-static/   OK
     testing: META-INF/maven/io.netty/netty-tcnative-boringssl-static/pom.properties   OK
     testing: META-INF/maven/io.netty/netty-tcnative-boringssl-static/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-epoll/   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-epoll/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-epoll/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-kqueue/   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-kqueue/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-kqueue/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-unix-common/   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-unix-common/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-transport-native-unix-common/pom.xml   OK
+    testing: META-INF/maven/io.netty/netty-transport/   OK
+    testing: META-INF/maven/io.netty/netty-transport/pom.properties   OK
+    testing: META-INF/maven/io.netty/netty-transport/pom.xml   OK
     testing: META-INF/maven/org.apache.ratis/   OK
     testing: META-INF/maven/org.apache.ratis/ratis-thirdparty-misc/   OK
     testing: META-INF/maven/org.apache.ratis/ratis-thirdparty-misc/pom.properties   OK
     testing: META-INF/maven/org.apache.ratis/ratis-thirdparty-misc/pom.xml   OK
+    testing: META-INF/maven/org.jctools/   OK
+    testing: META-INF/maven/org.jctools/jctools-core/   OK
+    testing: META-INF/maven/org.jctools/jctools-core/pom.properties   OK
+    testing: META-INF/maven/org.jctools/jctools-core/pom.xml   OK
     testing: META-INF/native-image/   OK
     testing: META-INF/native-image/io.netty/   OK
     testing: META-INF/native-image/io.netty/buffer/   OK
@@ -80,6 +123,7 @@
     testing: META-INF/services/org.apache.ratis.thirdparty.io.grpc.ManagedChannelProvider   OK
     testing: META-INF/services/org.apache.ratis.thirdparty.io.grpc.NameResolverProvider   OK
     testing: META-INF/services/org.apache.ratis.thirdparty.io.grpc.ServerProvider   OK
+    testing: META-INF/services/reactor.blockhound.integration.BlockHoundIntegration   OK
     testing: android/                 OK
     testing: android/annotation/      OK
     testing: android/annotation/SuppressLint.class   OK
@@ -5305,46 +5349,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/channel/pool/SimpleChannelPool$7.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/pool/SimpleChannelPool$ChannelPoolFullException.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/pool/SimpleChannelPool.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/DefaultRxtxChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannel$RxtxUnsafe$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannel$RxtxUnsafe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannelConfig$Databits.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannelConfig$Paritybit.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannelConfig$Stopbits.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxChannelOption.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/rxtx/RxtxDeviceAddress.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/DefaultSctpChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/DefaultSctpServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpChannelOption.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpNotificationHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpServerChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/SctpServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpChannel$NioSctpChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpServerChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpServerChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpServerChannel$NioSctpServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/nio/NioSctpServerChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpChannel$OioSctpChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpServerChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpServerChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpServerChannel$OioSctpServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/sctp/oio/OioSctpServerChannel.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/ChannelInputShutdownEvent.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/ChannelInputShutdownReadComplete.class   OK
@@ -5394,29 +5398,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/oio/OioSocketChannel$4.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/oio/OioSocketChannel.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/socket/oio/OioSocketChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/DefaultUdtChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/DefaultUdtServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtChannelOption.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtServerChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/UdtServerChannelConfig.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtAcceptorChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtByteConnectorChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtByteConnectorChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtByteRendezvousChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtMessageRendezvousChannel.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtProvider$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/channel/udt/nio/NioUdtProvider.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/unix/   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/unix/Buffer.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/channel/unix/DatagramSocketAddress.class   OK
@@ -5651,26 +5632,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/dns/TcpDnsQueryEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/dns/TcpDnsResponseDecoder$1.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/dns/TcpDnsResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyCommand.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyConstants.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessage$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageDecoder$HeaderExtractor.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageDecoder$LineHeaderExtractor.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageDecoder$StructHeaderExtractor.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageEncoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyProtocolException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyProtocolVersion.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyProxiedProtocol$AddressFamily.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyProxiedProtocol$TransportProtocol.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyProxiedProtocol.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxySSLTLV.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyTLV$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyTLV$Type.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/haproxy/HAProxyTLV.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/http/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/http/ClientCookieEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/http/CombinedHttpHeaders$CombinedHttpHeadersImpl$1.class   OK
@@ -6260,111 +6221,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/marshalling/ThreadLocalMarshallerProvider.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/marshalling/ThreadLocalUnmarshallerProvider.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/marshalling/UnmarshallerProvider.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/AbstractMemcacheObject.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/AbstractMemcacheObjectAggregator.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/AbstractMemcacheObjectDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/DefaultMemcacheContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/FullMemcacheMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/LastMemcacheContent$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/LastMemcacheContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/MemcacheContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/MemcacheMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/MemcacheObject.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec$Decoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec$Encoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheOpcodes.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/BinaryMemcacheServerCodec.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttCodecUtil$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttCodecUtil.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnAckMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnAckVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnectMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnectPayload.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnectReturnCode.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttConnectVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttDecoder$DecoderState.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttDecoder$Result.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttEncoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttFixedHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$AuthBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$ConnAckBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$ConnAckPropertiesBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$ConnectBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$DisconnectBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$PropertiesInitializer.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$PubAckBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$PublishBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$SubAckBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$SubscribeBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$UnsubAckBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders$UnsubscribeBuilder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageBuilders.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageFactory$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageFactory.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageIdAndPropertiesVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageIdVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttMessageType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$BinaryProperty.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$IntegerProperty.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$MqttProperty.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$MqttPropertyType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$StringPair.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$StringProperty.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$UserProperties.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties$UserProperty.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttProperties.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttPubAckMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttPubReplyMessageVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttPublishMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttQoS.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttReasonCodeAndPropertiesVariableHeader.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubAckMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubAckPayload.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubscribeMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubscribePayload.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubscriptionOption$RetainedHandlingPolicy.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttSubscriptionOption.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttTopicSubscription.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttUnacceptableProtocolVersionException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttUnsubAckMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttUnsubAckPayload.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttUnsubscribeMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/mqtt/MqttVersion.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/ProtobufDecoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/ProtobufDecoderNano.class   OK
@@ -6372,40 +6228,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/ProtobufEncoderNano.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/AbstractStringRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/ArrayHeaderRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/ArrayRedisMessage$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/ArrayRedisMessage$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/ArrayRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/BulkStringHeaderRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/BulkStringRedisContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/DefaultBulkStringRedisContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/DefaultLastBulkStringRedisContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/ErrorRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/FixedRedisMessagePool.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/FullBulkStringRedisMessage$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/FullBulkStringRedisMessage$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/FullBulkStringRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/InlineCommandRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/IntegerRedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/LastBulkStringRedisContent$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/LastBulkStringRedisContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisArrayAggregator$AggregateState.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisArrayAggregator.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisBulkStringAggregator.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisCodecException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisCodecUtil.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisConstants.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisDecoder$ToPositiveLongProcessor.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisMessagePool.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/RedisMessageType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/redis/SimpleStringRedisMessage.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/RtspDecoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/RtspEncoder.class   OK
@@ -6423,11 +6245,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/RtspResponseEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/RtspResponseStatuses.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/rtsp/RtspVersions.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/sctp/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/sctp/SctpInboundByteStreamHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/sctp/SctpMessageToMessageDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/sctp/SctpOutboundByteStreamHandler.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/CachingClassResolver.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/ClassLoaderClassResolver.class   OK
@@ -6443,132 +6260,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/ReferenceMap.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/SoftReferenceMap.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/serialization/WeakReferenceMap.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/DefaultLastSmtpContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/DefaultSmtpContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/DefaultSmtpRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/DefaultSmtpResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/LastSmtpContent$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/LastSmtpContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpCommand.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpRequestEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpRequests.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/smtp/SmtpUtils.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAddressType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthScheme.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksAuthStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdRequest$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdResponse$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCmdType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksCommonUtils.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksInitResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksMessageEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksMessageType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksProtocolVersion.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksRequestType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksResponseType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/SocksSubnegotiationVersion.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/UnknownSocksRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socks/UnknownSocksResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/AbstractSocksMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/SocksMessage.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/SocksPortUnificationServerHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/SocksVersion.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/AbstractSocks4Message.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/DefaultSocks4CommandResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4CommandRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4CommandResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4CommandStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4CommandType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4Message.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v4/Socks4ServerEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/AbstractSocks5Message.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5InitialResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/DefaultSocks5PasswordAuthResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AddressDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AddressEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AddressType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5AuthMethod.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5CommandType.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5InitialResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5Message.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequest.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponse.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthStatus.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/DefaultSpdyGoAwayFrame.class   OK
@@ -6636,51 +6327,13 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/SpdySynStreamFrame.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/SpdyVersion.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/spdy/SpdyWindowUpdateFrame.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/DefaultLastStompContentSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/DefaultStompContentSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/DefaultStompFrame.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/DefaultStompHeaders.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/LastStompContentSubframe$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/LastStompContentSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompCommand.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompConstants.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompContentSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompFrame.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompHeaders.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompHeadersSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframe.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeAggregator.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeDecoder$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeDecoder$HeaderParser.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeDecoder$State.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeDecoder$Utf8LineParser.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/stomp/StompSubframeEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/string/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/string/LineEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/string/LineSeparator.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/string/StringDecoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/string/StringEncoder.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlAttribute.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlCdata.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlCharacters.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlComment.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlContent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlDTD.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlDocumentEnd.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlDocumentStart.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlElement.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlElementEnd.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlElementStart.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlEntityReference.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlFrameDecoder.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlNamespace.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlProcessingInstruction.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/codec/xml/XmlSpace.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/flow/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/flow/FlowControlHandler$1.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/flow/FlowControlHandler$RecyclableArrayDeque$1.class   OK
@@ -6715,19 +6368,6 @@
     testing: org/apache/ratis/thirdparty/io/netty/handler/pcap/TCPPacket$TCPFlag.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/pcap/TCPPacket.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/pcap/UDPPacket.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/HttpProxyHandler$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/HttpProxyHandler$HttpClientCodecWrapper.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/HttpProxyHandler$HttpProxyConnectException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/HttpProxyHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyConnectException.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyConnectionEvent.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyHandler$1.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyHandler$2.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyHandler$LazyChannelPromise.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/ProxyHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/Socks4ProxyHandler.class   OK
-    testing: org/apache/ratis/thirdparty/io/netty/handler/proxy/Socks5ProxyHandler.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/ssl/   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/ssl/AbstractSniHandler.class   OK
     testing: org/apache/ratis/thirdparty/io/netty/handler/ssl/ApplicationProtocolAccessor.class   OK
@@ -8452,5 +8092,5 @@
     testing: org/apache/ratis/thirdparty/org/checkerframework/framework/qual/TypeUseLocation.class   OK
     testing: org/apache/ratis/thirdparty/org/checkerframework/framework/qual/Unused.class   OK
     testing: org/apache/ratis/thirdparty/org/checkerframework/framework/qual/UpperBoundFor.class   OK
-Archive:  misc/target/ratis-thirdparty-misc-0.8.0-59eb104-SNAPSHOT.jar
-No errors detected in compressed data of misc/target/ratis-thirdparty-misc-0.8.0-59eb104-SNAPSHOT.jar.
+Archive:  misc/target/ratis-thirdparty-misc-0.8.0-6042fd7-SNAPSHOT.jar
+No errors detected in compressed data of misc/target/ratis-thirdparty-misc-0.8.0-6042fd7-SNAPSHOT.jar.
```