### PR TITLE
RATIS-1523. Omit download progress in CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           java-version: 8
       - name: Run a full build
-        run: mvn -Ptest clean verify
+        run: mvn --no-transfer-progress -Ptest clean verify
       - name: Delete temporary build artifacts
         run: rm -rf ~/.m2/repository/org/apache/ratis
         if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not display transfer progress in CI when downloading plugins and dependencies.

https://issues.apache.org/jira/browse/RATIS-1523

## How was this patch tested?

CI
https://github.com/adoroszlai/ratis-thirdparty/runs/5184321559