### PR TITLE
RATIS-1515. Upgrade gRPC to 1.44.0, Netty to 4.1.74

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -173,6 +173,7 @@
                     <exclude>META-INF/native/libnetty_tcnative_linux_aarch_64.so</exclude>
                     <exclude>META-INF/native/libnetty_tcnative_linux_x86_64.so</exclude>
                     <exclude>META-INF/native/netty_tcnative_windows_x86_64.dll</exclude>
+                    <exclude>META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib</exclude>
                     <exclude>META-INF/native/libnetty_tcnative_osx_x86_64.jnilib</exclude>
                   </excludes>
                 </filter>
@@ -283,6 +284,10 @@
                 <fileSet>
                   <sourceFile>${project.build.directory}/classes/META-INF/native/netty_tcnative_windows_x86_64.dll</sourceFile>
                   <destinationFile>${project.build.directory}/classes/META-INF/native/${ratis.thirdparty.shaded.native.prefix}netty_tcnative_windows_x86_64.dll</destinationFile>
+                </fileSet>
+                <fileSet>
+                  <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_tcnative_osx_aarch_64.jnilib</sourceFile>
+                  <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_tcnative_osx_aarch_64.jnilib</destinationFile>
                 </fileSet>
                 <fileSet>
                   <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_tcnative_osx_x86_64.jnilib</sourceFile>

--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,9 @@
     <!--Version of protobuf to be shaded -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.43.2</shaded.grpc.version>
+    <shaded.grpc.version>1.44.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.63.Final</shaded.netty.version>
-    <!--Version of tcnative to be shaded -->
-    <shaded.netty.tcnative.version>2.0.38.Final</shaded.netty.tcnative.version>
+    <shaded.netty.version>4.1.74.Final</shaded.netty.version>
 
     <!-- third party library versions -->
     <commons-lang3.version>3.8.1</commons-lang3.version>
@@ -137,11 +135,6 @@
         <version>${shaded.netty.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${shaded.netty.tcnative.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opencensus</groupId>

--- a/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
+++ b/test/src/test/java/org/apache/ratis/thirdparty/demo/GrpcSslTest.java
@@ -48,7 +48,12 @@ public class GrpcSslTest {
             true,
             false);
     GrpcSslServer server = new GrpcSslServer(port, sslServerConf);
-    server.start();
+    try {
+      server.start();
+    } catch (Throwable t) {
+      LOG.error("error starting server", t);
+      throw t;
+    }
 
     Thread serverThread = new Thread(() -> {
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Upgrade gRPC to latest 1.44.0.
 * Upgrade Netty to latest 4.1.74.  Netty tcnative version (2.0.48) now comes from Netty POM to ensure consistency.

https://issues.apache.org/jira/browse/RATIS-1515

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis-thirdparty/runs/5186299011#step:5:217

Built locally, verified that all native libraries are shaded:

```
$ unzip -t misc/target/ratis-thirdparty-misc-0.8.0-SNAPSHOT.jar | grep netty_
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_resolver_dns_native_macos_x86_64.jnilib   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_tcnative_linux_aarch_64.so   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_tcnative_linux_x86_64.so   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_tcnative_osx_aarch_64.jnilib   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_tcnative_osx_x86_64.jnilib   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_transport_native_epoll_aarch_64.so   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_transport_native_epoll_x86_64.so   OK
    testing: META-INF/native/liborg_apache_ratis_thirdparty_netty_transport_native_kqueue_x86_64.jnilib   OK
    testing: META-INF/native/org_apache_ratis_thirdparty_netty_tcnative_windows_x86_64.dll   OK
```

Built Ratis with it and ran Ratis tests locally.

Also ran Thirdparty smoketests.  Note that `GrpcSslTest` failed on MacOS x86 despite having the native libraries for that platform:

```
[main] ERROR demo.GrpcSslTest (GrpcSslTest.java:testSslClientServer(54)) - error starting server
java.lang.UnsatisfiedLinkError: failed to load the required native library
...
Caused by: java.lang.IllegalArgumentException: Failed to load any of the given libraries: [netty_tcnative_osx_x86_64, netty_tcnative_x86_64, netty_tcnative]
...
	Suppressed: java.lang.UnsatisfiedLinkError: .../liborg_apache_ratis_thirdparty_netty_tcnative_osx_x86_644608907603584411798.dylib: dlopen(.../liborg_apache_ratis_thirdparty_netty_tcnative_osx_x86_644608907603584411798.dylib, 1): no suitable image found.  Did find:
	.../liborg_apache_ratis_thirdparty_netty_tcnative_osx_x86_644608907603584411798.dylib: cannot load 'liborg_apache_ratis_thirdparty_netty_tcnative_osx_x86_644608907603584411798.dylib' (load command 0x80000034 is unknown)
```