### PR TITLE
RATIS-1591. Bump netty to 4.1.77

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.44.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.74.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.77.Final</shaded.netty.version>
 
     <!-- third party library versions -->
     <commons-lang3.version>3.8.1</commons-lang3.version>


### PR DESCRIPTION
This should address [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823).