### PR TITLE
RATIS-1632. Upgrade gRPC to 1.48.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
     <!--Version of protobuf to be shaded -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.44.0</shaded.grpc.version>
+    <shaded.grpc.version>1.48.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.77.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.79.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.9</shaded.dropwizard.version>
     <shaded.dropwizard.ganglia.version>3.2.6</shaded.dropwizard.ganglia.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.48.1</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.79.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.77.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.9</shaded.dropwizard.version>
     <shaded.dropwizard.ganglia.version>3.2.6</shaded.dropwizard.ganglia.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <!--Version of protobuf to be shaded -->
     <shaded.protobuf.version>3.19.2</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.48.0</shaded.grpc.version>
+    <shaded.grpc.version>1.48.1</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
     <shaded.netty.version>4.1.79.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

~Upgrade gRPC to 1.48.0, Netty to 4.1.79 in Ratis Thirdparty.~
Upgrade gRPC to 1.48.1.

https://issues.apache.org/jira/browse/RATIS-1632

## How was this patch tested?

Regular CI:
~https://github.com/adoroszlai/ratis-thirdparty/runs/7451209538?check_suite_focus=true~
https://github.com/adoroszlai/ratis-thirdparty/runs/7654050988?check_suite_focus=true

~Ran Ratis unit tests with local build of Ratis Thirdparty.  `TestRaftReconfigurationWithGrpc` failed both with and without the change, otherwise OK.~
- [x] Ratis unit tests with local build of Ratis Thirdparty