### PR TITLE
RATIS-1725. Update github actions for node16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,12 +18,12 @@ on:
   - pull_request
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache for Maven dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -31,7 +31,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 8
       - name: Run a full build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Run a full build
         run: mvn --no-transfer-progress -Ptest clean verify


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Upgrade Github Actions action versions to ones that use node16, as node12 is being deprecated: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
 * Also upgrade runner to Ubuntu 20.04, because Ubuntu 18.04 is deprecated: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

https://issues.apache.org/jira/browse/RATIS-1725

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/3252226403