### PR TITLE
RATIS-2015. Node.js 16 actions are deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache for Maven dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
@@ -31,7 +31,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 8


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade GitHub actions to `v4` to get Node.js 20.

https://issues.apache.org/jira/browse/RATIS-2015

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/7644612136