### PR TITLE
RATIS-2064. Bump Netty to 4.1.109

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.58.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.100.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.109.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.21</shaded.dropwizard.version>
 

--- a/test/src/main/java/org/apache/ratis/thirdparty/demo/common/SslConfig.java
+++ b/test/src/main/java/org/apache/ratis/thirdparty/demo/common/SslConfig.java
@@ -24,15 +24,23 @@ import java.util.List;
 public class SslConfig {
   // TODO: allow configure cipher suites
   private final List<String> tlsCipherSuitesWithEncryption = Collections.unmodifiableList(Arrays.asList(
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
       "TLS_RSA_WITH_AES_128_GCM_SHA256",
       "TLS_RSA_WITH_AES_128_CBC_SHA",
-      "SSL_RSA_WITH_3DES_EDE_CBC_SHA"));
-
-  // "RSA" in this case refers to the key exchange algorithm,
-  // "SHA" refers to the message digest algorithm to provide integrity
-  // "NULL" is the encryption algorithm, to disable encryption.
-  // TODO: support NULL cipher from tcnative
-  private final List<String> tlsCipherSuitesNoEncryption = Collections.singletonList("TLS_RSA_WITH_AES_128_GCM_SHA256");
+      "TLS_RSA_WITH_AES_256_CBC_SHA",
+      "TLS_AES_128_GCM_SHA256",
+      "TLS_AES_256_GCM_SHA384",
+      "TLS_AES_128_GCM_SHA256",
+      "TLS_AES_256_GCM_SHA384",
+      "TLS_AES_128_GCM_SHA256",
+      "TLS_AES_256_GCM_SHA384",
+      "TLS_CHACHA20_POLY1305_SHA256"
+  ));
 
   private final boolean encryption;
 
@@ -49,7 +57,8 @@ public class SslConfig {
   }
 
   public List<String> getTlsCipherSuitesNoEncryption() {
-    return tlsCipherSuitesNoEncryption;
+    // TODO define list without encrpytion
+    return tlsCipherSuitesWithEncryption;
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Netty to latest (4.1.109 currently).

I had to tweak cipher list in tests to make `GrpcSslTest` to pass.  It was failing with `StacklessSSLHandshakeException: Connection closed while SSL/TLS handshake was in progress` due to one of the [changes in Netty 4.1.108](https://netty.io/news/2024/03/21/4-1-108-Final.html) related to SSL.

https://issues.apache.org/jira/browse/RATIS-2064

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/8877229601