### PR TITLE
RATIS-2110. Publish SBOM artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Run a full build
-        run: mvn --no-transfer-progress -Ptest clean verify
+        run: mvn --no-transfer-progress -Ptest -Prelease clean verify
       - name: Delete temporary build artifacts
         run: rm -rf ~/.m2/repository/org/apache/ratis
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Maven plugin versions -->
     <copy-rename-maven-plugin.version>1.0</copy-rename-maven-plugin.version>
+    <cyclonedx.version>2.8.0</cyclonedx.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <maven-bundle-plugin.version>2.5.3</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
@@ -267,6 +268,11 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>${maven-bundle-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>${cyclonedx.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -390,6 +396,18 @@
                 <id>check-licenses</id>
                 <goals>
                   <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeBom</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create and publish Software Bill of Materials (SBOM) for Ratis Third-party.  (See https://github.com/apache/ratis/pull/1110 for related PR in Ratis.)

https://cwiki.apache.org/confluence/display/SECURITY/Software+Bill+of+Materials+SBOM

https://issues.apache.org/jira/browse/RATIS-2110

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/9426923225/job/25970427146#step:5:67