### PR TITLE
RATIS-2119. Enable reproducible builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,9 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Run a full build
-        run: mvn --no-transfer-progress -Ptest -Prelease clean verify
+        run: mvn --no-transfer-progress -Ptest -Prelease clean install
+      - name: Check build reproducibility
+        run: mvn --no-transfer-progress -Ptest -Prelease -DskipTests clean verify artifact:compare
       - name: Delete temporary build artifacts
         run: rm -rf ~/.m2/repository/org/apache/ratis
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <url>http://issues.apache.org/jira/browse/RATIS</url>
   </issueManagement>
   <properties>
+    <project.build.outputTimestamp>2024-06-25T12:34:56Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Maven plugin versions -->
@@ -59,6 +60,7 @@
     <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-replacer-plugin.version>1.5.3</maven-replacer-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
@@ -219,6 +221,11 @@
             <!--Defer to the ratis-assembly sub-module.  It does all assembly-->
             <skipAssembly>true</skipAssembly>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
         </plugin>
         <!-- Make a jar and put the sources in the jar.
         In the parent pom, so submodules will do the right thing. -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Bump `maven-shade-plugin` to fix:
    ```
    $ mvn artifact:check-buildplan
    ...
    [ERROR] plugin with non-reproducible output: org.apache.maven.plugins:maven-shade-plugin:3.1.1, require minimum 3.5.2
    ```
- Enable reproducible builds by adding `project.build.outputTimestamp` property.
- Add new step in CI to verify that build is reproducible.

https://issues.apache.org/jira/browse/RATIS-2119

## How was this patch tested?

Same steps as in CI.

```
$ mvn --no-transfer-progress -Ptest -Prelease clean install
...
$ mvn --no-transfer-progress -Ptest -Prelease -DskipTests clean verify artifact:compare
...
[INFO] --- maven-artifact-plugin:3.5.1:compare (default-cli) @ ratis-thirdparty ---
...
[INFO] Reproducible Build output summary: 3 files ok
...
[INFO] --- maven-artifact-plugin:3.5.1:compare (default-cli) @ ratis-thirdparty-misc ---
...
[INFO] Reproducible Build output summary: 6 files ok
...
[INFO] --- maven-artifact-plugin:3.5.1:compare (default-cli) @ ratis-thirdparty-test ---
...
[INFO] Reproducible Build output summary: 15 files ok
```

CI:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/9666704190/job/26666824465