### PR TITLE
RATIS-2133. Include netty-proxy-handler dependency in the project.

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -231,7 +231,6 @@
                   <exclude>com.google.j2objc:j2objc-annotations</exclude>
                   <!-- Transitive stuff we don't need from netty -->
                   <exclude>io.netty:netty-codec-socks</exclude>
-                  <exclude>io.netty:netty-handler-proxy</exclude>
                   <!-- Transitive stuff we don't need coming from google deps -->
                   <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>


### PR DESCRIPTION
netty-proxy-handler artifact is required to handle cases where http proxy is configured in an application . 

Currently it is excluded from the misc jar. This caused issues in Ozone -> https://issues.apache.org/jira/browse/HDDS-11257.

https://issues.apache.org/jira/browse/RATIS-2133

Before the fix: 
```bash
misc % mvn help:effective-pom | grep "netty-handler-proxy"
        <artifactId>netty-handler-proxy</artifactId>
                  <exclude>io.netty:netty-handler-proxy</exclude>
```
After the fix
```bash
misc % mvn help:effective-pom | grep "netty-handler-proxy"
        <artifactId>netty-handler-proxy</artifactId>
```