### PR TITLE
RATIS-2247. Bump GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ on:
   - pull_request
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project
         uses: actions/checkout@v4


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ubuntu 20.04 is being deprecated: https://github.com/actions/runner-images/issues/11101

Upgrade to 24.04.

https://issues.apache.org/jira/browse/RATIS-2247

## How was this patch tested?

CI:
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/13249820869