### PR TITLE
RATIS-2265. Thirdparty should use the netty version recommended by gRPC.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,12 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!--Version of protobuf to be shaded -->
-    <shaded.protobuf.version>3.25.5</shaded.protobuf.version>
+    <shaded.protobuf.version>3.25.6</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.69.0</shaded.grpc.version>
+    <shaded.grpc.version>1.71.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.115.Final</shaded.netty.version>
+    <!--See grpc, netty combinations in https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
+    <shaded.netty.version>4.1.110.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.21</shaded.dropwizard.version>
 


### PR DESCRIPTION
See RATIS-2265