### PR TITLE
RATIS-2277. Ignore `.mvn/.develocity`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target
 .classpath
 .iml
 .idea
+.mvn/.develocity/
 *.versionsBackup


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make Git ignore `.mvn/develocity/`.

https://issues.apache.org/jira/browse/RATIS-2277

## How was this patch tested?

```
$ mvn -Ptest clean verify
$ git status
...
nothing to commit, working tree clean
```