### PR TITLE
RATIS-2276. Bump Netty to 4.1.119.Final, gRPC to 1.71.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
     <!--Version of protobuf to be shaded -->
     <shaded.protobuf.version>3.25.5</shaded.protobuf.version>
     <!--Version of grpc to be shaded -->
-    <shaded.grpc.version>1.69.0</shaded.grpc.version>
+    <shaded.grpc.version>1.71.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.115.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.119.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.21</shaded.dropwizard.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Netty to 4.1.119.Final, gRPC to 1.71.0.

https://issues.apache.org/jira/browse/RATIS-2276

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/14279589986