### PR TITLE
RATIS-2280. Autolink Ratis Jira issues in GitHub

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,13 +14,15 @@
 # limitations under the License.
 github:
   description: "Third-party dependencies for Apache Ratis"
-  homepage: http://ratis.apache.org/
+  homepage: https://ratis.apache.org/
   labels:
     - ratis
   enabled_merge_buttons:
     squash:  true
     merge:   false
     rebase:  false
+  autolink_jira:
+    - RATIS
 notifications:
   commits:      commits@ratis.apache.org
   issues:       issues@ratis.apache.org


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Automatically link mention of RATIS Jira issues in GitHub (e.g. RATIS-2280).
- Change site URL to HTTPS.

https://issues.apache.org/jira/browse/RATIS-2280

## How was this patch tested?

Similar config at https://github.com/apache/ratis/blob/master/.asf.yaml