### PR TITLE
RATIS-2297. Set default commit message to PR title

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,6 +19,7 @@ github:
     - ratis
   enabled_merge_buttons:
     squash:  true
+    squash_commit_message: PR_TITLE
     merge:   false
     rebase:  false
   autolink_jira:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set the default commit message to the PR title during merge.  The title can still be edited if needed, but we can avoid picking up single commit's possibly bad message.  (See [.asf.yaml documentation](https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#merge-buttons).)

https://issues.apache.org/jira/browse/RATIS-2297