### PR TITLE
RATIS-2298. Bump version to 1.0.10-SNAPSHOT after 1.0.9 release

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ratis</groupId>
     <artifactId>ratis-thirdparty</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.10-SNAPSHOT</version>
   </parent>
   <artifactId>ratis-thirdparty-misc</artifactId>
   <name>Apache Ratis Thirdparty Miscellaneous</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   <artifactId>ratis-thirdparty</artifactId>
   <groupId>org.apache.ratis</groupId>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.0.10-SNAPSHOT</version>
   <name>Apache Ratis Thirdparty</name>
   <packaging>pom</packaging>
   <description>Thirdparty dependencies for Apache Ratis</description>
@@ -48,7 +48,7 @@
     <url>http://issues.apache.org/jira/browse/RATIS</url>
   </issueManagement>
   <properties>
-    <project.build.outputTimestamp>2024-12-27T12:22:01Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2025-05-19T05:28:51Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Maven plugin versions -->

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.ratis</groupId>
     <artifactId>ratis-thirdparty</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.10-SNAPSHOT</version>
   </parent>
   <artifactId>ratis-thirdparty-test</artifactId>
   <name>Apache Ratis Thirdparty Test</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
mvn versions:set -DnewVersion=1.0.10-SNAPSHOT
```

https://issues.apache.org/jira/browse/RATIS-2298

## How was this patch tested?

```
mvn -Ptest clean verify
```