### PR TITLE
RATIS-2495. Bump version to 2.0.0-SNAPSHOT

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ratis</groupId>
     <artifactId>ratis-thirdparty</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>ratis-thirdparty-misc</artifactId>
   <name>Apache Ratis Thirdparty Miscellaneous</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   <artifactId>ratis-thirdparty</artifactId>
   <groupId>org.apache.ratis</groupId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <name>Apache Ratis Thirdparty</name>
   <packaging>pom</packaging>
   <description>Thirdparty dependencies for Apache Ratis</description>
@@ -48,7 +48,7 @@
     <url>http://issues.apache.org/jira/browse/RATIS</url>
   </issueManagement>
   <properties>
-    <project.build.outputTimestamp>2026-04-02T14:23:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-04-03T17:46:29Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Maven plugin versions -->

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.ratis</groupId>
     <artifactId>ratis-thirdparty</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>ratis-thirdparty-test</artifactId>
   <name>Apache Ratis Thirdparty Test</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-2491 proposes upgrade of Netty from 4.1 to 4.2.  There may be compatibility issues, so this PR bumps version to `2.0.0-SNAPSHOT` before we make the upgrade.

Afterwards we can create the maintenance branch from the previous commit.

https://issues.apache.org/jira/browse/RATIS-2495

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/23956006308