### PR TITLE
RATIS-2528. Bump Netty to 4.1.133

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.80.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.132.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.133.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.38</shaded.dropwizard.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Netty to 4.1.133 for 1.1.

https://issues.apache.org/jira/browse/RATIS-2528

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/25634706193