### PR TITLE
RATIS-2458. Ignore protobuf-java-util, too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,5 +33,5 @@ updates:
     cooldown:
       default-days: 7
     ignore:
-      - dependency-name: "com.google.protobuf:protobuf-java"
+      - dependency-name: "com.google.protobuf:*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Previously we added a rule to avoid major version upgrades for `protobuf-java` (ef22b104d995286539d8876bf99c26e9ac26e34b), which dependabot [confirmed](https://github.com/apache/ratis-thirdparty/pull/89#issuecomment-4147530040).  But now it wants to bump `protobuf-java-util` (#119).

```
updater | 2026/05/27 10:29:44 INFO <job_1386203310> Checking if com.google.protobuf:protobuf-java 3.25.9 needs updating
updater | 2026/05/27 10:29:44 INFO <job_1386203310> Ignored versions:
updater | 2026/05/27 10:29:44 INFO <job_1386203310>   version-update:semver-major - from .github/dependabot.yml
...
updater | 2026/05/27 10:29:44 INFO <job_1386203310> All updates for com.google.protobuf:protobuf-java were ignored
...
updater | 2026/05/27 10:29:51 INFO <job_1386203310> Checking if com.google.protobuf:protobuf-java-util 3.25.9 needs updating
...
updater | 2026/05/27 10:29:53 INFO <job_1386203310> Updating com.google.protobuf:protobuf-java, com.google.protobuf:protobuf-java-util
updater | 2026/05/27 10:29:53 INFO <job_1386203310> Submitting com.google.protobuf:protobuf-java, com.google.protobuf:protobuf-java-util pull request for creation
```

https://github.com/apache/ratis-thirdparty/actions/runs/26505443144/job/78056488218

This addendum tweaks the dependabot rule to ignore all protobuf artifacts.

https://issues.apache.org/jira/browse/RATIS-2458