### PR TITLE
RATIS-2566. Bump Netty to 4.1.135

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.82.0</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.133.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.135.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.39</shaded.dropwizard.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Netty to 4.1.135 for the `1.x` release line (`branch-1`).

https://issues.apache.org/jira/browse/RATIS-2566

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/28049412864