### PR TITLE
RATIS-2586. zizmor check should reflect failure in fork

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,9 +21,17 @@ on:
       - 'dependabot/**'
     tags:
       - '**'
+    paths:
+      - '.github/workflows/**'
   pull_request:
+    paths:
+      - '.github/workflows/**'
 
 permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,3 +38,5 @@ jobs:
 
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      with:
+        advanced-security: ${{ github.repository_owner == 'apache' }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

zizmor workflow added in RATIS-2493 provides feedback via "Code scanning results".  The workflow itself passes even if it finds issues to be fixed.  This does not work well in forks where code scanning is disabled.

To provide better feedback, the workflow should reflect scan results in forks.

Also:
- skip zizmor check for changes that do not touch workflows
- cancel run for obsolete commit (if new commit is pushed to the branch, but only in forks/PR)

https://issues.apache.org/jira/browse/RATIS-2586

## How was this patch tested?

Tested the same in `apache/ozone`:

Without the patch passes despite intentional violation:
https://github.com/adoroszlai/ozone/actions/runs/28570405264/job/84706670204#step:3:1058

Same violation with the patch fails:
https://github.com/adoroszlai/ozone/actions/runs/28570585965/job/84707233189#step:3:208

The patch without intentional violation passes (also in this repo):
https://github.com/adoroszlai/ozone/actions/runs/28570809169/job/84707932173#step:3:107
https://github.com/adoroszlai/ratis-thirdparty/actions/runs/28613321819