### PR TITLE
RATIS-2588. Add check for allowed action usage in workflows

### DIFF
--- a/.github/workflows/asf-allowlist-check.yaml
+++ b/.github/workflows/asf-allowlist-check.yaml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "ASF Allowlist Check"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    tags:
+      - '**'
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || case(github.repository_owner == 'apache', github.sha, github.ref_name) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository_owner != 'apache' }}
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check actions
+        uses: apache/infrastructure-actions/allowlist-check@775350a154e610e84c460cb1bbe2d2ab26c15cb3


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub workflows may fail silently when using any actions not allowed by ASF Infra.  See https://github.com/apache/infrastructure-actions/issues/574 for details.

This change add a new workflow that verifies action usage in (other) workflows.  See https://github.com/apache/infrastructure-actions/blob/main/allowlist-check/README.md

https://issues.apache.org/jira/browse/RATIS-2588

## How was this patch tested?

asf-allowlist-check: https://github.com/adoroszlai/ratis-thirdparty/actions/runs/28618694073/job/84868772959
zizmor: https://github.com/adoroszlai/ratis-thirdparty/actions/runs/28618694168/job/84868772888#step:3:95