### PR TITLE
RATIS-2590. Add Netty macOS aarch64 native dependencies

### DIFF
--- a/misc/pom.xml
+++ b/misc/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+      <classifier>osx-aarch_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <classifier>linux-aarch_64</classifier>
     </dependency>
@@ -71,6 +76,11 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-kqueue</artifactId>
       <classifier>osx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-aarch_64</classifier>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -191,6 +201,7 @@
                   <artifact>io.netty:netty-resolver-dns-native-macos</artifact>
                   <excludes>
                     <exclude>META-INF/native/libnetty_resolver_dns_native_macos_x86_64.jnilib</exclude>
+                    <exclude>META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib</exclude>
                   </excludes>
                 </filter>
                 <filter>
@@ -204,6 +215,7 @@
                   <artifact>io.netty:netty-transport-native-kqueue</artifact>
                   <excludes>
                     <exclude>META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib</exclude>
+                    <exclude>META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib</exclude>
                   </excludes>
                 </filter>
               </filters>
@@ -282,6 +294,10 @@
                   <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_resolver_dns_native_macos_x86_64.jnilib</destinationFile>
                 </fileSet>
                 <fileSet>
+                  <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_resolver_dns_native_macos_aarch_64.jnilib</sourceFile>
+                  <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_resolver_dns_native_macos_aarch_64.jnilib</destinationFile>
+                </fileSet>
+                <fileSet>
                   <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_tcnative_linux_aarch_64.so</sourceFile>
                   <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_tcnative_linux_aarch_64.so</destinationFile>
                 </fileSet>
@@ -312,6 +328,10 @@
                 <fileSet>
                   <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib</sourceFile>
                   <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_transport_native_kqueue_x86_64.jnilib</destinationFile>
+                </fileSet>
+                <fileSet>
+                  <sourceFile>${project.build.directory}/classes/META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib</sourceFile>
+                  <destinationFile>${project.build.directory}/classes/META-INF/native/lib${ratis.thirdparty.shaded.native.prefix}netty_transport_native_kqueue_aarch_64.jnilib</destinationFile>
                 </fileSet>
               </fileSets>
             </configuration>


### PR DESCRIPTION
## What changed
- Add the `osx-aarch_64` classifiers for `netty-resolver-dns-native-macos` and `netty-transport-native-kqueue`.
- Update the shade filters so the unshaded macOS aarch64 native libraries are excluded from the final artifact.
- Add copy/rename entries so the macOS aarch64 resolver and kqueue native libraries use the Ratis thirdparty shaded native prefix.

## Why
This completes Netty native support for Apple Silicon macOS. `netty-tcnative-boringssl-static` already contributes an `osx-aarch_64` native library, but the macOS DNS resolver and kqueue transport were only packaged for `osx-x86_64`.

Jira: https://issues.apache.org/jira/browse/RATIS-2590

## Validation
- `mvn -q -pl misc -DskipTests clean package`
