### PR TITLE
RATIS-2608. Bump Netty to 4.1.136

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <!--Version of grpc to be shaded -->
     <shaded.grpc.version>1.82.1</shaded.grpc.version>
     <!--Version of Netty to be shaded -->
-    <shaded.netty.version>4.1.135.Final</shaded.netty.version>
+    <shaded.netty.version>4.1.136.Final</shaded.netty.version>
     <!--Version of dropwizard to be shaded -->
     <shaded.dropwizard.version>4.2.39</shaded.dropwizard.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Netty from 4.1.135 to 4.1.136 for 1.x release line.  (2.x uses Netty 4.2.)

https://issues.apache.org/jira/browse/RATIS-2608

## How was this patch tested?

https://github.com/adoroszlai/ratis-thirdparty/actions/runs/29324848092