### PR TITLE
RATIS-2473. Ignore JUnit 6+ due to Java 17 requirement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,6 @@ updates:
     ignore:
       - dependency-name: "com.google.protobuf:*"
         update-types: ["version-update:semver-major"]
+      # requires Java 17
+      - dependency-name: "org.junit:junit-bom"
+        versions: [">=6.0.0"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stick to JUnit 5, since v6 requires Java 17.

https://issues.apache.org/jira/browse/RATIS-2473
